### PR TITLE
Ao fetch article roles

### DIFF
--- a/src/components/article/preview/article-preview-list.jsx
+++ b/src/components/article/preview/article-preview-list.jsx
@@ -3,7 +3,6 @@ import React from "react";
 import { ArticlePreview } from "./article-preview";
 
 const ArticlePreviewList = ({ heading, articles }) => {
-  console.log({ heading });
   return (
     <section className="mt-[120px]">
       {heading && <Text variant="h4" value={heading} className="mb-[40px]" />}

--- a/src/components/article/preview/article-preview.jsx
+++ b/src/components/article/preview/article-preview.jsx
@@ -4,14 +4,14 @@ import { NLink, Text } from "components";
 
 import RightArrowIcon from "assets/images/svgs/arrow-right.svg";
 
-const ArticlePreview = ({ title, slug, featuredImage, excerpt }) => {
+const ArticlePreview = ({ title, slug, featuredImage, role }) => {
   return (
     <div className="gradient-blue-to-red p-[1px] rounded">
       <div className="relative overflow-hidden  rounded ">
         <div className="absolute z-10 left-0 right-0 top-0 w-full h-full flex flex-col justify-end">
           <div className="bg-gradient-to-t from-black via-black to-transparent pl-[29px]   pr-4 pb-[39px] pt-[120px]">
             <Text variant="h5" value={title} isPrimary />
-            <Text variant="p16" html={excerpt} className="" />
+            <Text variant="p16" value={role} />
             <NLink
               to={`/story/${slug}`}
               className="flex items-center mt-2 group"

--- a/src/templates/home/featured-stories.jsx
+++ b/src/templates/home/featured-stories.jsx
@@ -16,6 +16,7 @@ export const HomeFeaturedStories = () => {
           title
           slug
           excerpt
+          role
 
           featuredImage {
             node {
@@ -57,7 +58,11 @@ export const HomeFeaturedStories = () => {
           <div className="md:col-span-5 col-span-12 flex flex-col justify-center">
             <div>
               <Text variant="h2">{firstItem.title}</Text>
-              <Text variant="p18" className="mb-8" html={firstItem.excerpt} />
+              <Text
+                variant="p18"
+                value={firstItem.role}
+                className=" mt-1 mb-4 "
+              />
 
               <Button
                 href={`/story/${firstItem.slug}`}

--- a/src/templates/stories/stories.jsx
+++ b/src/templates/stories/stories.jsx
@@ -12,16 +12,12 @@ import Share from "./components/share";
 import CopyButton from "./components/copy-button";
 
 const Story = ({ data }) => {
-  const { title, content, date, author, excerpt, featuredImage } = data.wpPost;
+  const { title, content, date, author, role, excerpt, featuredImage } =
+    data.wpPost;
 
   const readTime = readingTime(content);
   const relatedStories = data.allWpPost.nodes;
 
-  const excerptLength = excerpt.length;
-  const openingTagLength = 3; // <p>
-  const closingTagLength = 5; // </p>\n
-
-  console.log({ excerpt });
   return (
     <Layout title={title} description={excerpt} ignoreSiteName>
       <Container className="md:py-[100px] py-[50px] ">
@@ -30,11 +26,7 @@ const Story = ({ data }) => {
             <MetaData date={date} readTime={readTime.minutes} />
             <Author author={author} />
             <Text variant="h3">
-              {title} &#8212;{" "}
-              {excerpt.substring(
-                openingTagLength,
-                excerptLength - closingTagLength
-              )}
+              {title} &#8212; {role}
             </Text>
             <GatsbyImage
               image={
@@ -112,6 +104,7 @@ export const pageQuery = graphql`
       content
       excerpt
       date(formatString: "LL")
+      role
       featuredImage {
         node {
           localFile {
@@ -140,6 +133,7 @@ export const pageQuery = graphql`
         title
         slug
         excerpt
+        role
         featuredImage {
           node {
             localFile {


### PR DESCRIPTION
## 1. Objective
- Use the custom field 'Role' in WordPress to display user's roles instead of excerpt

## 2. Description of change

N/A

## 3. Quality assurance

- Assert that the guest's role shows up both on the landing page and single story page

## 4. Operations impact

N/A

## 5. Business impact

More stability and sanity

## 6. Priority of Change

Normal
