### PR TITLE
Move Analytics/Gtag to Web Worker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,6 @@ yarn-error.log
 .pnp.js
 # Yarn Integrity file
 .yarn-integrity
+
+# Partytown
+static/~partytown

--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -5,3 +5,18 @@ import "./src/style/tailwind.css";
 export const wrapRootElement = ({ element }) => (
   <SubscribersContextProvider>{element}</SubscribersContextProvider>
 );
+
+export const onRouteUpdate = ({ location }) => {
+  if (process.env.NODE_ENV !== "production") {
+    return null;
+  }
+
+  const pagePath = location
+    ? location.pathname + location.search + location.hash
+    : undefined;
+  setTimeout(() => {
+    if (typeof gtag === "function") {
+      gtag("event", "page_view", { page_path: pagePath });
+    }
+  }, 100);
+};

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -28,14 +28,6 @@ module.exports = {
       },
     },
     {
-      resolve: "gatsby-plugin-google-tagmanager",
-      options: {
-        id: process.env.GOOGLE_TAG_MANAGER_ID,
-        includeInDevelopment: false,
-        defaultDataLayer: { platform: "gatsby" },
-      },
-    },
-    {
       resolve: `gatsby-source-filesystem`,
       options: {
         name: `images`,

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,4 +1,5 @@
 const path = require("path");
+const { copyLibFiles } = require("@builder.io/partytown/utils");
 
 exports.createPages = async ({ graphql, actions }) => {
   const { createPage } = actions;
@@ -28,3 +29,6 @@ exports.createPages = async ({ graphql, actions }) => {
   });
 };
 
+exports.onPreBuild = async () => {
+  await copyLibFiles(path.join(__dirname, "static", "~partytown"));
+};

--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -5,3 +5,34 @@
  */
 
 // You can delete this file if you're not using it
+
+import React from "react";
+import { Partytown } from "@builder.io/partytown/react";
+
+// You might prefer to add these as an env vars
+const ORIGIN = "https://www.googletagmanager.com";
+const GATSBY_GA_MEASUREMENT_ID = process.env.GOOGLE_TAG_MANAGER_ID;
+
+export const onRenderBody = ({ setHeadComponents }) => {
+  if (process.env.NODE_ENV !== "production" && process.env.NODE_ENV !== "test")
+    return null;
+
+  setHeadComponents([
+    <Partytown key="partytown" forward={["gtag"]} />,
+    <script
+      key="google-analytics"
+      type="text/partytown"
+      src={`${ORIGIN}/gtag/js?id=${GATSBY_GA_MEASUREMENT_ID}`}
+    />,
+    <script
+      key="google-analytics-config"
+      type="text/partytown"
+      dangerouslySetInnerHTML={{
+        __html: `window.dataLayer = window.dataLayer || [];
+        window.gtag = function gtag(){ window.dataLayer.push(arguments);}
+        gtag('js', new Date()); 
+        gtag('config', '${GATSBY_GA_MEASUREMENT_ID}', { send_page_view: false })`,
+      }}
+    />,
+  ]);
+};

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "version": "0.1.0",
   "author": "FourthCanvas <dev@fourthcanvas.co>",
   "dependencies": {
+    "@builder.io/partytown": "^0.8.0",
     "@hookform/resolvers": "^2.8.8",
     "@mailchimp/mailchimp_marketing": "^3.0.80",
     "@netlify/classnames-template-literals": "^1.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1023,6 +1023,11 @@
     "@babel/helper-validator-identifier" "^7.16.7"
     to-fast-properties "^2.0.0"
 
+"@builder.io/partytown@^0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@builder.io/partytown/-/partytown-0.8.0.tgz#98543c1a5ba204d6b950edb53ab8a50b7df125d3"
+  integrity sha512-M6H7nSMwW2dHd1/MQ+9J1Jqdw22uhl1nKv90kIiL9G7gjFVqqouQp4qSS1oZclmtW1XjAa4Q5UnbHB4iytmxZA==
+
 "@endemolshinegroup/cosmiconfig-typescript-loader@3.0.2":
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/@endemolshinegroup/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-3.0.2.tgz#eea4635828dde372838b0909693ebd9aafeec22d"
@@ -9719,7 +9724,6 @@ qs@^6.5.1:
   version "6.11.1"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.11.1.tgz#6c29dff97f0c0060765911ba65cbc9764186109f"
   integrity sha512-0wsrzgTz/kAVIeuxSjnpGC56rzYtr6JT/2BwEvMaPhFIoYa1aGO8LbzuU1R0uUYQkLpWBTOj0l/CLAJB64J6nQ==
-
   dependencies:
     side-channel "^1.0.4"
 


### PR DESCRIPTION
## 1. Objective
Partytown js theoretically moves all analytics data to a web worker meaning things are handle in the background this prevent analytics like Google Analytics from blocking the main thread which usually impacts performance.

Tbh: I just copied and pasted the code from [this article](https://www.gatsbyjs.com/blog/how-to-add-google-analytics-gtag-to-gatsby-using-partytown/)

## 2. Description of change
N/A

## 3. Quality assurance

Check performance hopefully the build succeeds

## 4. Operations impact
N/A

## 5. Business impact

Improved speed

## 6. Priority of Change

Normal
