### PR TITLE
fix: team reddish gradient text on about-us page for mobile devices

### DIFF
--- a/src/templates/about-us/team.jsx
+++ b/src/templates/about-us/team.jsx
@@ -72,4 +72,5 @@ const teamNameStyle = ctl(`
   bg-clip-text
   mb-2
   md:mb-3
+  inline-block
 `);


### PR DESCRIPTION
## 1. Objective
This fixes the reddish gradient not displaying for the team text on mobile devices.

Related Link(s)
- [22-fix-team-reddish-gradient-text-not-showing-on-mobile](https://trello.com/c/VR435yHx/22-fix-team-reddish-gradient-text-not-showing-on-mobile)


## 2. Priority of Change
- Normal
