### PR TITLE
ao_fix: update color black

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -11,6 +11,9 @@ module.exports = {
       },
 
       colors: {
+        black: {
+          DEFAULT: "#101010",
+        },
         primary: {
           DEFAULT: "#121212",
           100: "#FFFFFF",


### PR DESCRIPTION
## 1. Objective
For accessibility, we are updating the color 'black' on the website.

Related Link(s)
- [Trello Ticket](https://trello.com/c/NCcLLqtI/14-change-the-website-background-colour)

## 2. Description of change
Updated the default black to: `#101010`

## 3. Quality assurance

Inspect any element on the website with background or color of `black`, the value should be: `#101010`

## 4. Operations impact
N/A

## 5. Business impact

Let our users breeethe🥺

## 6. Priority of Change

Normal
