### PR TITLE
Setup Single page for Resources

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -27,6 +27,42 @@ exports.createPages = async ({ graphql, actions }) => {
       },
     });
   });
+
+  const SingleResourcePage = path.resolve(
+    "./src/templates/resources/single.jsx"
+  );
+  const allWpCategories = await graphql(`
+    query {
+      allWpCategory {
+        nodes {
+          name
+          slug
+          resources {
+            nodes {
+              title
+              url
+            }
+          }
+        }
+      }
+    }
+  `);
+
+  const resourceCategories =
+    await allWpCategories.data.allWpCategory.nodes.filter(
+      category => category.resources.nodes.length > 0
+    );
+
+  resourceCategories.forEach(categoryNode => {
+    const { slug } = categoryNode;
+    createPage({
+      path: `resources/${slug}`,
+      component: SingleResourcePage,
+      context: {
+        slug,
+      },
+    });
+  });
 };
 
 exports.onPreBuild = async () => {

--- a/plugins/gatsby-mock-graphql/data/categories.js
+++ b/plugins/gatsby-mock-graphql/data/categories.js
@@ -2,45 +2,55 @@ exports.categories = {
   wpCategory: [
     {
       name: "3D Arts & Design",
+      slug: "3d",
       description: null,
     },
     {
       name: "Brand Design",
+      slug: "brand-design",
       description: null,
     },
     {
       name: "Cinematography & Video Editing",
+      slug: "cinematography",
       description: null,
     },
     {
       name: "Community Management",
+      slug: "community-management",
       description:
         "The process of building an authentic community among a business's customers, employees, and partners.",
     },
     {
       name: "Customer Success",
+      slug: "customer-success",
       description:
         "This is a method for ensuring customers reach their desired outcomes when using an organization's product or service.",
     },
     {
       name: "Customer Support",
+      slug: "customer-support",
       description: null,
     },
     {
       name: "Freelancing",
+      slug: "freelancing",
       description: null,
     },
     {
       name: "Graphic Design",
+      slug: "graphic-design",
       description: null,
     },
     {
       name: "Marketing",
+      slug: "marketing",
       description:
         "The promotion of brands to connect with potential customers using the internet and other forms of digital communication.",
     },
     {
       name: "No Code Development",
+      slug: "no-code-development",
       description:
         "This is a software development approach that requires few, if any, programming skills to quickly build an application.",
     },

--- a/src/pages/about-us.tsx
+++ b/src/pages/about-us.tsx
@@ -22,7 +22,10 @@ const AboutPage = () => {
   `);
 
   return (
-    <Layout title="About us">
+    <Layout
+      title="About us"
+      description="Like you, our path to tech wasn’t straight but yours doesn’t have to be like that."
+    >
       <>
         <AboutUsHeader />
         <div className={arrowsContainerStyle}>

--- a/src/pages/donate.tsx
+++ b/src/pages/donate.tsx
@@ -70,7 +70,10 @@ const DonatePage = () => {
     makePaymentBasedOnGateWay[payment_gateway](onSucess, onClose);
   };
   return (
-    <Layout title="Donate">
+    <Layout
+      title="Donate"
+      description="The work we do is largely funded by individuals who buy our merch and organizations who make direct donations."
+    >
       <DonateHeader />
 
       <Container className={formContainerStyle}>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -8,7 +8,11 @@ import { Resources } from "components/resources";
 
 const IndexPage = () => {
   return (
-    <Layout title="Other Faces of Tech" ignoreSiteName={true}>
+    <Layout
+      title="Other Faces of Tech"
+      ignoreSiteName={true}
+      description="Let's help you put a face your career in tech. Through stories, roadmaps, and resources"
+    >
       <>
         <HomeHeader />
 

--- a/src/pages/resources.tsx
+++ b/src/pages/resources.tsx
@@ -39,7 +39,10 @@ const ResourcePage = () => {
     : allResourcesCategory;
 
   return (
-    <Layout title="Resources">
+    <Layout
+      title="Resources"
+      description="Carefully selected books, schools, courses to kickstart and supercharge your non-coding career in tech "
+    >
       <ResourcesHeader />
       <div className={searchWrapperStyle}>
         <SearchIcon className="md:w-auto w-[24px]" />

--- a/src/pages/roadmaps.tsx
+++ b/src/pages/roadmaps.tsx
@@ -76,7 +76,11 @@ const DonatePage = () => {
     }
   };
   return (
-    <Layout title="Roadmaps">
+    <Layout
+      title="Roadmaps"
+      description="A clear roadmap for you.
+    Gain clarity on the right steps to kickstart or level up your career in tech."
+    >
       <RoadmapsHeader />
 
       <Container className={formContainerStyle}>

--- a/src/templates/resources/category.jsx
+++ b/src/templates/resources/category.jsx
@@ -5,15 +5,17 @@ import RightArrowIcon from "assets/images/svgs/arrow-right.svg";
 import { ImageWithMock } from "components/image-with-mock";
 
 export const ResourceCategory = ({ title, list = [] }) => {
-  const categoryId = title.replace(/\s/g, "-").toLowerCase();
+  const categoryId = title && title.replace(/\s/g, "-").toLowerCase();
   return (
     <section id={categoryId}>
-      <header className="flex items-center">
-        <Text variant="h4" className=" mr-9 ">
-          {title}
-        </Text>
-        <hr className="gradient-yellow-to-blue h-[1px] border-0 md:flex hidden flex-1" />
-      </header>
+      {title && (
+        <header className="flex items-center">
+          <Text variant="h4" className=" mr-9 ">
+            {title}
+          </Text>
+          <hr className="gradient-yellow-to-blue h-[1px] border-0 md:flex hidden flex-1" />
+        </header>
+      )}
 
       <content className={contentResourceListStyle}>
         {list.map((resource, index) => {

--- a/src/templates/resources/header.jsx
+++ b/src/templates/resources/header.jsx
@@ -3,7 +3,7 @@ import Container from "components/container";
 import { Br, Text } from "components";
 import { graphql, useStaticQuery } from "gatsby";
 
-export const ResourcesHeader = () => {
+export const ResourcesHeader = ({ title, totalCount }) => {
   const resourcesQuery = useStaticQuery(graphql`
     query MyQuery {
       allWpResource {
@@ -18,8 +18,9 @@ export const ResourcesHeader = () => {
     <header>
       <Container className=" pt-[50px] md:pt-[100px] px-5 pb-[40px] text-center max-w-[1000px]">
         <Text variant="h2">
-          {noOfResources}+ resources to kickstart your <Br on="desktop" />{" "}
-          non-coding career in tech.
+          {totalCount || noOfResources}+ resources to kickstart your{" "}
+          <Br on="desktop" />{" "}
+          {title ? `${title} career` : "non-coding career in tech."}
         </Text>
         <Text variant="p16">
           *PS: This is only a directory, we have no affiliation with the brands

--- a/src/templates/resources/single.jsx
+++ b/src/templates/resources/single.jsx
@@ -1,0 +1,65 @@
+import React from "react";
+
+import Layout from "components/layout";
+import { Newsletter } from "components";
+import Container from "components/container";
+import ctl from "@netlify/classnames-template-literals";
+
+import { ResourceCategory, ResourcesHeader } from "templates/resources";
+import { graphql } from "gatsby";
+
+const ResourcePage = ({ data }) => {
+  const { name, resources } = data.wpCategory ?? {};
+
+  const totalCount = resources.nodes.length;
+  return (
+    <Layout title="Resources">
+      <ResourcesHeader title={name} totalCount={totalCount} />
+
+      <Container className={formContainerStyle}>
+        <ResourceCategory list={resources.nodes} />
+      </Container>
+      <section>
+        <Newsletter />
+      </section>
+    </Layout>
+  );
+};
+
+export default ResourcePage;
+
+export const pageQuery = graphql`
+  query ResourcePageQuery($slug: String) {
+    wpCategory(slug: { eq: $slug }) {
+      name
+      resources {
+        nodes {
+          title
+          url
+          featuredImage {
+            node {
+              localFile {
+                childImageSharp {
+                  gatsbyImageData
+                }
+              }
+            }
+          }
+          resourceTypes {
+            nodes {
+              name
+            }
+          }
+          resourcePayments {
+            nodes {
+              name
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+const formContainerStyle = ctl(`
+mb-[160px]
+`);


### PR DESCRIPTION
## 1. Objective

- Setup a single page for each resource category (this is an experiment/proof of concept to help increase our SEO juice)

## 2. Description of change

- Dynamically created new pages with `gatsby-node`

## 3. Quality assurance

- Visit `/resources/3d`
- You should see only resources related to 3d
- You can try other slug available in the mock as well, you should see only resources related to that category
- the existing resource page should still continue to work

## 4. Operations impact

N/A

## 5. Business impact

Improve SEO

## 6. Priority of Change

Normal